### PR TITLE
Add interface definitions and core logic to start installed plugins

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 source =
     gordon_janitor
+omit = gordon_janitor/interfaces.py
 
 [paths]
 source =

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,15 @@ To generate documentation:
 
 Then navigate to ``localhost:$PORT``!
 
+To watch for changes and automatically reload in the browser:
+
+.. code-block:: bash
+
+    (env) $ cd docs
+    (env) $ make livehtml  # default port 8888
+    # to change port
+    (env) $ make livehtml PORT=8080
+
 
 Code of Conduct
 ===============

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,4 @@
 -e .
 sphinx==1.7.0
 sphinx-autobuild==0.7.1
+sphinxcontrib-zopeext==0.2.1

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,2 +1,3 @@
 -e .
-sphinx==1.6.5
+sphinx==1.7.0
+sphinx-autobuild==0.7.1

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-Minimal makefile for Sphinx documentation
+# Minimal makefile for Sphinx documentation
 #
 
 # You can set these variables from the command line.
@@ -7,14 +7,19 @@ SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = gordon-janitor
 SOURCEDIR     = .
 BUILDDIR      = _build
+PORT         := 8888
+
 
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help livehtml Makefile
+
+livehtml:
+	sphinx-autobuild -p $(PORT) -b html $(SOURCEDIR) $(BUILDDIR)/html $(O)
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,8 @@ extensions = [
     'sphinx.ext.napoleon',
     # link to other projects' documentation
     'sphinx.ext.intersphinx',
+    # zope interface doc help
+    'sphinxcontrib.zopeext.autointerface',
 ]
 
 
@@ -102,6 +104,7 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
+autodoc_default_flags = ['members']
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -3,6 +3,7 @@ Configuring the Gordon Janitor Service
 
 
 .. automodule:: gordon_janitor.main
+    :noindex:
 
 
 Example Configuration

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ User's Guide
 
    config
    plugins
+   interfaces
    api
 
 

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -1,0 +1,5 @@
+Plugin Interfaces
+=================
+
+.. currentmodule:: gordon_janitor.interfaces
+.. automodule:: gordon_janitor.interfaces

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -2,7 +2,7 @@ Gordon Janitor's Plugin System
 ==============================
 
 .. automodule:: gordon_janitor.plugins_loader
-
+    :noindex:
 
 Writing a Plugin
 ----------------

--- a/gordon_janitor/exceptions.py
+++ b/gordon_janitor/exceptions.py
@@ -20,3 +20,7 @@ class GordonJanitorError(Exception):
 
 class LoadPluginError(GordonJanitorError):
     """Error loading plugin."""
+
+
+class MissingPluginError(GordonJanitorError):
+    """Missing a required plugin."""

--- a/gordon_janitor/interfaces.py
+++ b/gordon_janitor/interfaces.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2017 Spotify AB
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Interface definitions for Gordon Janitor Plugins.
+
+Please see :doc:`plugins` for more information on writing a plugin for
+the Gordon Janitor service.
+"""
+
+from zope.interface import Interface
+
+
+class IGenericPlugin(Interface):
+    """**Do not** implement this interface directly.
+
+    Use :py:class:`IAuthority`, :py:class:`IReconciler`, or
+    :py:class:`IPublisher` instead.
+
+    Args:
+        config (dict): Plugin-specific configuration.
+        plugin_kwargs (dict): Plugin-specific keyword arguments. See
+            specific interface declarations.
+    """
+    def __init__(config, **plugin_kwargs):
+        """Initialize a Janitor Plugin client."""
+
+    async def start():
+        """Start plugin in the main event loop.
+
+        Once required work is all processed, :py:meth:`done` needs to
+        be called.
+        """
+
+    async def done():
+        """Cleanup once plugin-specific work is done.
+
+        Cleanup work might include allowing outstanding asynchronous
+        Python tasks to finish, cancelling them if they extend beyond a
+        desired timeout, and/or closing HTTP sessions.
+        """
+
+
+class IAuthority(IGenericPlugin):
+    """Scan source of truth(s) of hosts and emit messages to Reconciler.
+
+    The purpose of this client is to consult a source of truth, for
+    example, the list instances APIs in Google Compute Engine or AWS
+    EC2, or consulting one's own database of hosts. A message per DNS
+    zone with every instance record (per service owner's own
+    requirements) will then be put onto the ``rrset_channel`` queue for
+    a Reconciler to - you guessed it - reconcile.
+
+    Args:
+        config (dict): Authority-specific configuration.
+        rrset_channel (asyncio.Queue): queue to put record set messages
+            for later validation.
+        metrics (obj): Optional object to emit Authority-specific
+            metrics.
+    """
+    def __init__(config, rrset_channel, metrics=None):
+        """Initialize an Authority Plugin client."""
+
+
+class IReconciler(IGenericPlugin):
+    """Validate current records in DNS against desired Authority.
+
+    Clients that implement :py:class:`IReconciler` will create a change
+    message for the configured :py:class:`IPublisher` client plugin to
+    consume if there is a discrepancy between records in DNS and the
+    desired state.
+
+    Once validation is done, the :py:class:`IReconciler` client will
+    need to emit a ``None`` message to the :py:attr:`changes_channel`
+    queue, signalling to an :py:class:`IPublisher` client to publish the
+    message to a pub/sub to which `Gordon
+    <https://github.com/spotify/gordon>`_ subscribes.
+
+    Args:
+        config (dict): Reconciler-specific configuration.
+        rrset_channel (asyncio.Queue): queue from which to consume
+            record set messages to validate.
+        changes_channel (asyncio.Queue): queue to publish corrective
+            messages to be published.
+        metrics (obj): Optional object to emit Reconciler-specific
+            metrics.
+    """
+    def __init__(config, rrset_channel, changes_channel, metrics=None):
+        """Initialize a Reconciler Plugin client."""
+
+
+class IPublisher(IGenericPlugin):
+    """Publish change messages to the pub/sub Gordon consumes.
+
+    Clients that implement :py:class:`IPublisher` will consume from the
+    :py:attr:`changes_channel` queue and publish the message to the
+    configured pub/sub for which `Gordon
+    <https://github.com/spotify/gordon>`_ subscribes.
+
+    Args:
+        config (dict): Publisher-specific configuration.
+        changes_channel (asyncio.Queue): queue to consume the
+             corrective messages needing to be published.
+        metrics (obj): Optional object to emit Publisher-specific
+            metrics.
+    """
+    def __init__(config, changes_channel, metrics=None):
+        """Initialize a Publisher Plugin client."""

--- a/gordon_janitor/plugins_loader.py
+++ b/gordon_janitor/plugins_loader.py
@@ -64,13 +64,13 @@ from gordon_janitor import exceptions
 PLUGIN_NAMESPACE = 'gordon_janitor.plugins'
 
 
-def _init_plugins(active_plugins, installed_plugins, plugin_configs):
+def _init_plugins(active, installed, configs, kwargs):
     inited_plugins, inited_plugin_names, errors = [], [], []
-    for plugin_name, unloaded_plugin in installed_plugins.items():
-        if plugin_name not in active_plugins:
+    for plugin_name, unloaded_plugin in installed.items():
+        if plugin_name not in active:
             continue
         plugin_class = unloaded_plugin.load()
-        plugin_config = plugin_configs.get(plugin_name)
+        plugin_config = configs.get(plugin_name)
 
         # check against `None` because `plugin_config` could be `{}`,
         # which should be handled by the plugin's logic (i.e. accept all
@@ -82,7 +82,7 @@ def _init_plugins(active_plugins, installed_plugins, plugin_configs):
             continue
 
         try:
-            plugin_object = plugin_class(plugin_config)
+            plugin_object = plugin_class(plugin_config, **kwargs)
             inited_plugins.append(plugin_object)
             inited_plugin_names.append(plugin_name)
         except Exception as e:
@@ -187,7 +187,7 @@ def _gather_installed_plugins():
     return gathered_plugins
 
 
-def load_plugins(config):
+def load_plugins(config, plugin_kwargs):
     """
     Discover and instantiate plugins.
 
@@ -206,4 +206,5 @@ def load_plugins(config):
         return [], [], []
     plugin_namespaces = _get_plugin_config_keys(installed_plugins)
     plugin_configs = _load_plugin_configs(plugin_namespaces, config)
-    return _init_plugins(active_plugins, installed_plugins, plugin_configs)
+    return _init_plugins(
+        active_plugins, installed_plugins, plugin_configs, plugin_kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click==6.7
 setuptools==38.2.5
 toml==0.9.3.1
 ulogger==1.0.1
+zope.interface==4.4.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@ coverage==4.4.2
 flake8==3.5.0
 flake8-import-order==0.16
 pytest==3.2.5
+pytest-asyncio==0.8.0
 pytest-catchlog==1.2.2
 pytest-cov==2.5.1
 pytest-mock==1.6.3

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,8 +22,14 @@ import pytest
 
 
 class FakePlugin:
-    def __init__(self, config):
+    def __init__(self, config, **kwargs):
         self.config = config
+
+    async def start(self):
+        pass
+
+    async def done(self):
+        pass
 
 
 @pytest.fixture
@@ -36,42 +42,51 @@ def plugin_exc_mock():
 
 @pytest.fixture(scope='session')
 def config_file():
+    plugins = '["authority.plugin", "reconciler.plugin", "publisher.plugin"]'
     return ('[core]\n'
-            'plugins = ["one.plugin", "two.plugin"]\n'
+            f'plugins = {plugins}\n'
             'debug = true\n'
             '[core.logging]\n'
             'level = "debug"\n'
             'handlers = ["stream"]\n'
-            '[one]\n'
+            '[authority]\n'
             'a_key = "a_value"\n'
             'b_key = "b_value"\n'
-            '[one.plugin]\n'
+            '[authority.plugin]\n'
             'a_key = "another_value"\n'
-            '[two.plugin]\n'
-            'd_key = "d_value"')
+            '[reconciler.plugin]\n'
+            'd_key = "d_value"\n'
+            '[publisher.plugin]\n'
+            'e_key = "e_value"')
 
 
 @pytest.fixture
 def loaded_config():
     return {
         'core': {
-            'plugins': ['one.plugin', 'two.plugin'],
+            'plugins': [
+                'authority.plugin', 'reconciler.plugin', 'publisher.plugin'],
             'debug': True,
             'logging': {
                 'level': 'debug',
                 'handlers': ['stream'],
             }
         },
-        'one': {
+        'authority': {
             'a_key': 'a_value',
             'b_key': 'b_value',
             'plugin': {
                 'a_key': 'another_value',
             },
         },
-        'two': {
+        'reconciler': {
             'plugin': {
                 'd_key': 'd_value',
+            },
+        },
+        'publisher': {
+            'plugin': {
+                'e_key': 'e_value',
             },
         },
     }
@@ -80,7 +95,7 @@ def loaded_config():
 @pytest.fixture
 def plugins(mocker):
     plugins = {}
-    names = ['one.plugin', 'two.plugin']
+    names = ['authority.plugin', 'reconciler.plugin', 'publisher.plugin']
     for name in names:
         plugin_mock = mocker.MagicMock(pkg_resources.EntryPoint, autospec=True)
         plugin_mock.name = name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

This patch introduces interfaces to enforce a couple of methods and init behavior of janitor plugins. Interfaces helps when the janitor starts the plugins' logic. 

This also adds logic to start the whole service. Depending on which interface each loaded plugin provides, the janitor will start it in a deterministic order (publisher first, followed by reconciler, then authority). 

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:

Docs for developing plugins is still needed :-/ As well as a proper system/integration test.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

cc @spotify/alf 