### PR TITLE
Rename interface methods

### DIFF
--- a/gordon_janitor/interfaces.py
+++ b/gordon_janitor/interfaces.py
@@ -36,15 +36,15 @@ class IGenericPlugin(Interface):
     def __init__(config, **plugin_kwargs):
         """Initialize a Janitor Plugin client."""
 
-    async def start():
+    async def run():
         """Start plugin in the main event loop.
 
-        Once required work is all processed, :py:meth:`done` needs to
+        Once required work is all processed, :py:meth:`cleanup` needs to
         be called.
         """
 
-    async def done():
-        """Cleanup once plugin-specific work is done.
+    async def cleanup():
+        """Cleanup once plugin-specific work is cleanup.
 
         Cleanup work might include allowing outstanding asynchronous
         Python tasks to finish, cancelling them if they extend beyond a

--- a/gordon_janitor/main.py
+++ b/gordon_janitor/main.py
@@ -125,7 +125,7 @@ def _gather_providers(plugins, debug):
             exc = exceptions.MissingPluginError(msg.format(name=provider))
             missing.append(exc)
     if missing:
-        base_msg = 'Issue starting plugins: '
+        base_msg = 'Issue running plugins: '
         _log_or_exit_on_exceptions(base_msg, missing, debug=debug)
 
     return providers
@@ -139,9 +139,9 @@ async def _run(plugins, debug):
     tasks = []
     for name, provider in providers.items():
         try:
-            tasks.append(provider.start())
+            tasks.append(provider.run())
         except AttributeError as e:
-            base_msg = 'Plugin missing required "start" method: '
+            base_msg = 'Plugin missing required "run" method: '
             _log_or_exit_on_exceptions(base_msg, name, debug=debug)
 
     await asyncio.gather(*tasks)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -25,10 +25,10 @@ class FakePlugin:
     def __init__(self, config, **kwargs):
         self.config = config
 
-    async def start(self):
+    async def run(self):
         pass
 
-    async def done(self):
+    async def cleanup(self):
         pass
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

@matt0bi @descent3me and I decided to rename the main async methods from `start` and `done` to `run` and `cleanup` as it makes more sense to us.

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->

N/A

**Special notes for your reviewer**:

Once this is merged in, I'll create a new dev release to upload to PyPI, then update the gordon-janitor-gcp plugin.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Rename interface methods.
```

@matt0bi @spotify/alf 
