### PR TITLE
Load config only for active plugins

### DIFF
--- a/gordon_janitor/plugins_loader.py
+++ b/gordon_janitor/plugins_loader.py
@@ -158,9 +158,9 @@ def _load_plugin_configs(plugin_names, config):
 def _get_plugin_config_keys(plugins):
     # Make sure all parent namespaces of a plugin are available
     # to load config for easy config handling
-    defined_plugin_namespace = plugins.keys()
+
     all_config_keys = set()
-    for namespace in defined_plugin_namespace:
+    for namespace in plugins:
         namespaces = namespace.split('.')
         namespaces_to_build = []
         while len(namespaces):
@@ -204,7 +204,7 @@ def load_plugins(config, plugin_kwargs):
     active_plugins = _get_activated_plugins(config, installed_plugins)
     if not active_plugins:
         return [], [], []
-    plugin_namespaces = _get_plugin_config_keys(installed_plugins)
+    plugin_namespaces = _get_plugin_config_keys(active_plugins)
     plugin_configs = _load_plugin_configs(plugin_namespaces, config)
     return _init_plugins(
         active_plugins, installed_plugins, plugin_configs, plugin_kwargs)

--- a/tests/unit/test_plugins_loader.py
+++ b/tests/unit/test_plugins_loader.py
@@ -62,6 +62,11 @@ def exp_inited_plugins(plugin_config):
 
 @pytest.fixture
 def mock_iter_entry_points(mocker, monkeypatch, plugins):
+    # Extra plugin without configuration - should be skipped as inactive.
+    inactive_plugin = mocker.MagicMock(pkg_resources.EntryPoint)
+    inactive_plugin.name = 'inactive.plugin'
+    plugins['inactive.plugin'] = inactive_plugin
+
     mock_plugins = plugins.values()
 
     mock_iter_entry_points = mocker.MagicMock(pkg_resources.iter_entry_points)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:

The plugin loader only loads plugins that have associated configuration, making it possible for a user to specify plugins to load even if there are multiple plugins installed (eg. multiple authority plugins). However, the plugin loader will attempt to load the configuration for all installed plugins and will exit-fail on plugins that don't have any configuration.

I caught this when trying to run the janitor with the internal set of plugins. The janitor complains about a None object because the internal set of plugins extends `gordon-janitor-gcp`, meaning that there are 5 plugins installed, but only 3 are used as specified in the config. Here's the traceback:

```
# snip
  File "/usr/src/app/.venv/lib/python3.6/site-packages/gordon_janitor/main.py", line 165, in run
    plugin_kwargs)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/gordon_janitor/plugins_loader.py", line 228, in load_plugins
    plugin_configs = _load_plugin_configs(plugin_namespaces, config)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/gordon_janitor/plugins_loader.py", line 161, in _load_plugin_configs
    config, plugin, plugin_names)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/gordon_janitor/plugins_loader.py", line 141, in _get_namespaced_config
    plugin_config = config.copy()
AttributeError: 'NoneType' object has no attribute 'copy'
```

**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

@spotify/alf 