### PR TITLE
Correctly handle plugin loader errors

### DIFF
--- a/gordon_janitor/main.py
+++ b/gordon_janitor/main.py
@@ -167,9 +167,9 @@ def run(config_root):
     plugin_names, plugins, errors, plugin_kwargs = plugins_loader.load_plugins(
         config, plugin_kwargs)
 
-    if errors:
-        base_msg = 'Plugin was not loaded:'
-        _log_or_exit_on_exceptions(base_msg, errors, debug_mode)
+    for err_plugin, exc in errors:
+        base_msg = f'Plugin was not loaded: {err_plugin}'
+        _log_or_exit_on_exceptions(base_msg, exc, debug=debug_mode)
 
     if not plugin_names:
         logging.error('No plugins to run, exiting.')

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -81,41 +81,36 @@ def load_plugins_mock(mocker, monkeypatch):
     return load_plugins_mock
 
 
-args = 'error_type'
-params = [
-    'list', 'obj'
-]
-
-
-@pytest.mark.parametrize(args, params)
-def test_log_or_exit_on_exceptions_no_debug(error_type, plugin_exc_mock,
-                                            mocker, monkeypatch):
+@pytest.mark.parametrize('error_type', ['list', 'obj'])
+def test_log_or_exit_on_exceptions_no_debug(
+        error_type, plugin_exc_mock, caplog, capsys):
     """Raise SystemExit if debug flag is off."""
-    logging_mock = mocker.MagicMock(main.logging, autospec=True)
-    monkeypatch.setattr(main, 'logging', logging_mock)
-
-    error = ('bad.plugin', plugin_exc_mock)
+    error = plugin_exc_mock
     if error_type == 'list':
-        error = [('bad.plugin', error)]
+        error = [error]
     with pytest.raises(SystemExit) as e:
         main._log_or_exit_on_exceptions('base msg', error, debug=False)
-
     e.match('1')
-    logging_mock.error.assert_called_once()
-    logging_mock.warn.assert_not_called()
+
+    assert 1 == len(caplog.records)
+    for record in caplog.records:
+        assert 'ERROR' == record.levelname
+
+    # Assert the bug from https://github.com/spotify/gordon-janitor/pull/14
+    # has not reappeared.
+    out, err = capsys.readouterr()
+    assert '--- Logging error ---' not in err
 
 
-def test_log_or_exit_on_exceptions_debug(plugin_exc_mock, mocker, monkeypatch):
+def test_log_or_exit_on_exceptions_debug(
+        plugin_exc_mock, mocker, monkeypatch, caplog, capsys):
     """Do not exit out if debug flag is on."""
-    logging_mock = mocker.MagicMock(main.logging, autospec=True)
-    monkeypatch.setattr(main, 'logging', logging_mock)
+    msg, error = 'Plugin not loaded "bad.plugin"', plugin_exc_mock
+    main._log_or_exit_on_exceptions(msg, error, debug=True)
 
-    errors = [('bad.plugin', plugin_exc_mock)]
-
-    main._log_or_exit_on_exceptions('base_msg', errors, debug=True)
-
-    logging_mock.warn.assert_called_once()
-    logging_mock.error.assert_not_called()
+    assert 1 == len(caplog.records)
+    for record in caplog.records:
+        assert 'WARNING' == record.levelname
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
Previously when trying to run janitor, if there was an error you would get strange unhelpful output.  
```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.6/logging/__init__.py", line 992, in emit
    msg = self.format(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 838, in format
    return fmt.format(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 583, in format
    record.exc_text = self.formatException(record.exc_info)
  File "/usr/lib/python3.6/logging/__init__.py", line 529, in formatException
    tb = ei[2]
IndexError: tuple index out of range
Call stack:
  File "/usr/src/app/.venv/bin/gordon-janitor", line 11, in <module>
    sys.exit(run())
  File "/usr/src/app/.venv/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/gordon_janitor/main.py", line 172, in run
    _log_or_exit_on_exceptions(base_msg, errors, debug_mode)
  File "/usr/src/app/.venv/lib/python3.6/site-packages/gordon_janitor/main.py", line 99, in _log_or_exit_on_exceptions
    log_level_func(base_msg, exc_info=exception)
Message: 'Plugin was not loaded:'
Arguments: ()
```

This simplifies that and includes the plugin name, similar to how it is handled in [gordon](https://github.com/spotify/gordon/blob/develop/gordon/main.py#L188). 


**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:
The tests in this commit were designed to fail before the change to main was made. It seems this bug was hidden a bit because we were passing correct input in the unit tests, but we were not verifying the output in testing the run method which had the actual (incorrect) input.


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Correctly handle plugin loader errors
```

@spotify/alf 