### PR TITLE
Use deep merge on config files

### DIFF
--- a/gordon_janitor/main.py
+++ b/gordon_janitor/main.py
@@ -49,13 +49,22 @@ from gordon_janitor import interfaces
 plugins_loader.PLUGIN_NAMESPACE = 'gordon_janitor.plugins'
 
 
+def _deep_merge_dict(a, b):
+    """Additively merge right side dict into left side dict."""
+    for k, v in b.items():
+        if k in a and isinstance(a[k], dict) and isinstance(v, dict):
+            _deep_merge_dict(a[k], v)
+        else:
+            a[k] = v
+
+
 def _load_config(root=''):
     conf, error = {}, False
     conf_files = ['gordon-janitor.toml', 'gordon-janitor-user.toml']
     for conf_file in conf_files:
         try:
             with open(os.path.join(root, conf_file), 'r') as f:
-                conf.update(toml.load(f))
+                _deep_merge_dict(conf, (toml.load(f)))
         except IOError:
             error = True
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines <https://github.com/spotify/gordon-janitor/blob/master/CONTRIBUTING.rst>
2. If the PR is unfinished, please prefix the subject line with [WIP], [DRAFT], or [RFC].
-->

**What this PR does / why we need it**:
This PR changes the way multiple config files. Due to the highly nested nature of Gordon configs I suspect this is what we intended to have from the start. 

Example of the difference below:
```
# gordon-janitor.toml
[core.logging]
level = "info"
handlers = ["syslog"]
fmt = "%(asctime)s.%(msecs)03dZ gordon[%(process)d]: %(message)s"

# gordon-janitor-user.toml
[core.logging]
level = "error"

# final loaded config before PR
{'core': {'logging': {'level' : 'error'}}}

# final loaded config after PR
{'core': {'logging': {'level' : 'error', 'handlers':['syslog'], 'fmt': '%(asctime)s.%(msecs)03dZ gordon[%(process)d]: %(message)s'}}}
```


**Which issue(s) this PR fixes**
<!-- optional; in `fixes #<issue number>, fixes #<issue_number>, ...` format, will close the issue(s) when PR gets merged: -->
Fixes #

**Special notes for your reviewer**:
I think it would be wise to be consistent and add this to Gordon DNS as well, but wanted to get approval on the approach before doing more work.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, start the release note with the string "action required: ".
2. If no release note is required, just write "NONE".
-->
```release-note
Deep merge user config file.
```
@spotify/alf 